### PR TITLE
Update font-awesome/jqm-icon-pack-2.1.2-fa.css

### DIFF
--- a/font-awesome/jqm-icon-pack-2.1.2-fa.css
+++ b/font-awesome/jqm-icon-pack-2.1.2-fa.css
@@ -22,11 +22,6 @@
 	margin: -10px -10px auto auto !important;	
 }
 
-/* fix for icons within header bars */
-.ui-navbar .ui-icon {
-	margin-top: 0 !important;
-}
-
 /* supporting original icons */
 .ui-icon-plus, .ui-icon-minus, .ui-icon-delete, .ui-icon-arrow-r,
 .ui-icon-arrow-l, .ui-icon-arrow-u, .ui-icon-arrow-d, .ui-icon-check,


### PR DESCRIPTION
ui-icon margin customization for ui-navbar introduce an alignment bug with jquery mobile 1.1.x.
Delete this customization to let jqm manage icon position into navbar
