### PR TITLE
Updated CSS files with a hack to get the HD icons to display on 'retina' devices

### DIFF
--- a/font-awesome/jqm-icon-pack-2.1.2-fa.css
+++ b/font-awesome/jqm-icon-pack-2.1.2-fa.css
@@ -19,7 +19,7 @@
 	margin: 1px 1px 2px 2px !important;
 }
 .ui-li-link-alt .ui-btn-inner .ui-icon {
-	margin: -10px -10px auto auto !important;	
+	margin: -10px -10px auto auto !important;
 }
 
 /* fix for icons within header bars */
@@ -31,7 +31,7 @@
 .ui-icon-plus, .ui-icon-minus, .ui-icon-delete, .ui-icon-arrow-r,
 .ui-icon-arrow-l, .ui-icon-arrow-u, .ui-icon-arrow-d, .ui-icon-check,
 .ui-icon-gear, .ui-icon-refresh, .ui-icon-forward, .ui-icon-back,
-.ui-icon-grid, .ui-icon-star, .ui-icon-alert, .ui-icon-info, .ui-icon-home, .ui-icon-search, .ui-icon-searchfield:after, 
+.ui-icon-grid, .ui-icon-star, .ui-icon-alert, .ui-icon-info, .ui-icon-home, .ui-icon-search, .ui-icon-searchfield:after,
 .ui-icon-checkbox-off, .ui-icon-checkbox-on, .ui-icon-radio-off, .ui-icon-radio-on, .ui-icon-email , .ui-icon-page,
 .ui-icon-question , .ui-icon-foursquare, .ui-icon-dollar , .ui-icon-euro,
 .ui-icon-pound , .ui-icon-apple , .ui-icon-chat , .ui-icon-trash , .ui-icon-mappin , .ui-icon-direction,
@@ -41,28 +41,30 @@
 	background-image: url('images/icons-18-white-pack.png') !important;
 }
 
-@media only screen and (-webkit-min-device-pixel-ratio: 1.5),
-       only screen and (min--moz-device-pixel-ratio: 1.5),
-       only screen and (min-resolution: 240dpi) {
-	
+@media only screen and (-webkit-min-device-pixel-ratio: 1.3),
+		only screen and (-o-min-device-pixel-ratio: 3/2),
+		only screen and (min--moz-device-pixel-ratio: 1.3),
+		only screen and (min-device-pixel-ratio: 1.3),
+		only screen and (min-resolution: 1.3dppx) {
+
 	.ui-icon-plus, .ui-icon-minus, .ui-icon-delete, .ui-icon-arrow-r,
 	.ui-icon-arrow-l, .ui-icon-arrow-u, .ui-icon-arrow-d, .ui-icon-check,
 	.ui-icon-gear, .ui-icon-refresh, .ui-icon-forward, .ui-icon-back,
-	.ui-icon-grid, .ui-icon-star, .ui-icon-alert, .ui-icon-info, .ui-icon-home, .ui-icon-search, .ui-icon-searchfield:after, 
+	.ui-icon-grid, .ui-icon-star, .ui-icon-alert, .ui-icon-info, .ui-icon-home, .ui-icon-search, .ui-icon-searchfield:after,
 	.ui-icon-checkbox-off, .ui-icon-checkbox-on, .ui-icon-radio-off, .ui-icon-radio-on, .ui-icon-email , .ui-icon-page,
 	.ui-icon-question , .ui-icon-foursquare, .ui-icon-dollar , .ui-icon-euro,
 	.ui-icon-pound , .ui-icon-apple , .ui-icon-chat , .ui-icon-trash , .ui-icon-mappin , .ui-icon-direction,
 	.ui-icon-heart , .ui-icon-wrench , .ui-icon-play , .ui-icon-pause , .ui-icon-stop , .ui-icon-person , .ui-icon-music,
 	.ui-icon-wifi , .ui-icon-phone , .ui-icon-power ,
 	.ui-icon-lightning , .ui-icon-drink , .ui-icon-android {
-		background-image: url('images/icons-36-white-pack.png');
+		background-image: url('images/icons-36-white-pack.png') !important;
 		-moz-background-size: 774px 54px;
 		-o-background-size: 774px 54px;
 		-webkit-background-size: 774px 54px;
 		background-size: 774px 54px;
 	}
 	.ui-icon-alt {
-		background-image: url('images/icons-36-black-pack.png'	);
+		background-image: url('images/icons-36-black-pack.png');
 	}
 }
 

--- a/original/jqm-icon-pack-2.0-original.css
+++ b/original/jqm-icon-pack-2.0-original.css
@@ -38,14 +38,16 @@
 /* HD/"retina" sprite
 -----------------------------------------------------------------------------------------------------------*/
 
-@media only screen and (-webkit-min-device-pixel-ratio: 1.5),
-       only screen and (min--moz-device-pixel-ratio: 1.5),
-       only screen and (min-resolution: 240dpi) {
-	
+@media only screen and (-webkit-min-device-pixel-ratio: 1.3),
+		only screen and (-o-min-device-pixel-ratio: 3/2),
+		only screen and (min--moz-device-pixel-ratio: 1.3),
+		only screen and (min-device-pixel-ratio: 1.3),
+		only screen and (min-resolution: 1.3dppx) {
+
 	.ui-icon-plus, .ui-icon-minus, .ui-icon-delete, .ui-icon-arrow-r,
 	.ui-icon-arrow-l, .ui-icon-arrow-u, .ui-icon-arrow-d, .ui-icon-check,
 	.ui-icon-gear, .ui-icon-refresh, .ui-icon-forward, .ui-icon-back,
-	.ui-icon-grid, .ui-icon-star, .ui-icon-alert, .ui-icon-info, .ui-icon-home, .ui-icon-search, .ui-icon-searchfield:after, 
+	.ui-icon-grid, .ui-icon-star, .ui-icon-alert, .ui-icon-info, .ui-icon-home, .ui-icon-search, .ui-icon-searchfield:after,
 	.ui-icon-checkbox-off, .ui-icon-checkbox-on, .ui-icon-radio-off, .ui-icon-radio-on, .ui-icon-email , .ui-icon-page,
 	.ui-icon-question , .ui-icon-foursquare , .ui-icon-twitter , .ui-icon-facebook , .ui-icon-dollar , .ui-icon-euro,
 	.ui-icon-pound , .ui-icon-apple , .ui-icon-chat , .ui-icon-trash , .ui-icon-bell , .ui-icon-mappin , .ui-icon-direction,


### PR DESCRIPTION
I have not tested this on a "retina-display" of an iPhone (4[s],5) but my Galaxy Nexus GSM with Android 4.1.2 has a 315PPI display and with -webkit-min-device-pixel-ratio: 1.3 it is caught by the Media query. Needless to say, when using unmodified versions of this CSS, I cannot not for the life of me get my Nexus to display the HD icons.

I tried playing with the pixel ratios in the media queries with no success. I replaced it with my own Media query from a LESS CSS mixin I use which catches lower density displays that are just barely what you would call "retina".

This still didn't work so I busted out Remote Chrome Dev Tools using Chrome for Android on my phone and to my surprise, it was not actually using the background-image url of the HD icons, but actually using the SD version and still following the background-size of the Media query.

I added an !important to the HD set and presto! Now, I know adding !important is bad-form and frowned upon but in this case it is a hack that works for now without further investigation. This my first pull so please give me feedback!
